### PR TITLE
Add vulnerability dna

### DIFF
--- a/agent/openvas_agent.py
+++ b/agent/openvas_agent.py
@@ -197,9 +197,12 @@ class OpenVasAgent(
                 vulnerability_location = self._prepare_vulnerable_target_data(
                     target, line_result
                 )
+                title = line_result.get("NVT Name")
+                if title is None or title == "":
+                    title = "OpenVas Finding"
                 self.report_vulnerability(
                     entry=kb.Entry(
-                        title=line_result.get("NVT Name", "OpenVas Finding"),
+                        title=title,
                         risk_rating=_severity_map(
                             line_result.get("severity", "INFO").lower()
                         ).name,
@@ -222,7 +225,7 @@ class OpenVasAgent(
                     ),
                     vulnerability_location=vulnerability_location,
                     dna=_compute_dna(
-                        vuln_title=line_result.get("NVT Name", "OpenVas Finding"),
+                        vuln_title=title,
                         vuln_location=vulnerability_location,
                     ),
                 )

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -1,4 +1,4 @@
-"""Unit/home/oussama/ostorlab_projects/agent_openvas/tests for OpenVas class."""
+"""Unittests for OpenVas class."""
 
 import json
 
@@ -200,11 +200,7 @@ def testAgentOpenVas_withDomainScopeArgumentAndDomainNotInScope_targetShouldNotB
     Services with domains not in the scope not should be processed."""
     mocker.patch("agent.openvas.OpenVas.start_scan", return_value="hduzehfuhehfuhef")
     mocker.patch("agent.openvas.OpenVas.wait_task", return_value=None)
-    with open(
-        "/home/oussama/ostorlab_projects/agent_openvas/tests/openvas_result.csv",
-        "r",
-        encoding="UTF-8",
-    ) as f:
+    with open("tests/openvas_result.csv", "r", encoding="UTF-8") as f:
         mocker.patch("agent.openvas.OpenVas.get_results", return_value=f.read())
         mock_report_vulnerability = mocker.patch(
             "agent.openvas_agent.OpenVasAgent.report_vulnerability", return_value=None

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -20,7 +20,11 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
         "agent.openvas.OpenVas.start_scan", return_value="hduzehfuhehfuhef"
     )
     mocker.patch("agent.openvas.OpenVas.wait_task", return_value=None)
-    with open("tests/openvas_result.csv", "r", encoding="UTF-8") as f:
+    with open(
+        "/home/oussama/ostorlab_projects/agent_openvas/tests/openvas_result.csv",
+        "r",
+        encoding="UTF-8",
+    ) as f:
         mocker.patch("agent.openvas.OpenVas.get_results", return_value=f.read())
         mock_report_vulnerability = mocker.patch(
             "agent.openvas_agent.OpenVasAgent.report_vulnerability", return_value=None
@@ -66,7 +70,7 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
         star_scan_mocker.assert_called_with(scan_message.data.get("host"), None)
         mock_report_vulnerability.assert_called_with(
             entry=kb.Entry(
-                title="",
+                title="OpenVas Finding",
                 risk_rating="INFO",
                 references={},
                 short_description="",
@@ -83,7 +87,7 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
-            dna='{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
+            dna='{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": "OpenVas Finding"}',
         )
 
 

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -1,4 +1,4 @@
-"""Unittests for OpenVas class."""
+"""Unit/home/oussama/ostorlab_projects/agent_openvas/tests for OpenVas class."""
 
 import json
 
@@ -138,7 +138,7 @@ def testAgentOpenVas_whenLinkAssetAndBinaryAvailable_RunScan(
 
         mock_report_vulnerability.assert_called_with(
             entry=kb.Entry(
-                title="",
+                title="OpenVas Finding",
                 risk_rating="INFO",
                 references={},
                 short_description="",
@@ -155,7 +155,7 @@ def testAgentOpenVas_whenLinkAssetAndBinaryAvailable_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
-            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
+            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": "OpenVas Finding"}',
         )
 
 
@@ -200,7 +200,11 @@ def testAgentOpenVas_withDomainScopeArgumentAndDomainNotInScope_targetShouldNotB
     Services with domains not in the scope not should be processed."""
     mocker.patch("agent.openvas.OpenVas.start_scan", return_value="hduzehfuhehfuhef")
     mocker.patch("agent.openvas.OpenVas.wait_task", return_value=None)
-    with open("tests/openvas_result.csv", "r", encoding="UTF-8") as f:
+    with open(
+        "/home/oussama/ostorlab_projects/agent_openvas/tests/openvas_result.csv",
+        "r",
+        encoding="UTF-8",
+    ) as f:
         mocker.patch("agent.openvas.OpenVas.get_results", return_value=f.read())
         mock_report_vulnerability = mocker.patch(
             "agent.openvas_agent.OpenVasAgent.report_vulnerability", return_value=None
@@ -263,7 +267,7 @@ def testAgentOpenVas_whenServiceAssetGiven_RunScan(
 
         mock_report_vulnerability.assert_called_with(
             entry=kb.Entry(
-                title="",
+                title="OpenVas Finding",
                 risk_rating="INFO",
                 references={},
                 short_description="",
@@ -280,7 +284,7 @@ def testAgentOpenVas_whenServiceAssetGiven_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
-            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
+            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": "OpenVas Finding"}',
         )
 
 
@@ -347,7 +351,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
         )
         args1 = {
             "entry": kb.Entry(
-                title="",
+                title="OpenVas Finding",
                 risk_rating="INFO",
                 references={},
                 short_description="",
@@ -364,7 +368,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
             "risk_rating": vuln_utils.RiskRating.INFO,
             "technical_detail": f"\n```json\n{json.dumps(output1, indent=4, sort_keys=True)}\n```",
             "vulnerability_location": vulnerability_location,
-            "dna": '{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
+            "dna": '{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": "OpenVas Finding"}',
         }
 
         output2 = {
@@ -404,7 +408,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
         )
         args2 = {
             "entry": kb.Entry(
-                title="",
+                title="OpenVas Finding",
                 risk_rating="INFO",
                 references={},
                 short_description="",
@@ -421,7 +425,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
             "risk_rating": vuln_utils.RiskRating.INFO,
             "technical_detail": f"\n```json\n{json.dumps(output2, indent=4, sort_keys=True)}\n```",
             "vulnerability_location": vulnerability_location,
-            "dna": '{"location": {"ipv4": {"host": "128.0.0.2", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "443"}]}, "title": ""}',
+            "dna": '{"location": {"ipv4": {"host": "128.0.0.2", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "443"}]}, "title": "OpenVas Finding"}',
         }
 
         openvas_agent_no_scope.process(ip_range_message)

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -20,11 +20,7 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
         "agent.openvas.OpenVas.start_scan", return_value="hduzehfuhehfuhef"
     )
     mocker.patch("agent.openvas.OpenVas.wait_task", return_value=None)
-    with open(
-        "/home/oussama/ostorlab_projects/agent_openvas/tests/openvas_result.csv",
-        "r",
-        encoding="UTF-8",
-    ) as f:
+    with open("tests/openvas_result.csv", "r", encoding="UTF-8") as f:
         mocker.patch("agent.openvas.OpenVas.get_results", return_value=f.read())
         mock_report_vulnerability = mocker.patch(
             "agent.openvas_agent.OpenVasAgent.report_vulnerability", return_value=None

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -58,7 +58,7 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
                     metadata_type=vuln_utils.MetadataType.PORT, value="80"
                 )
             ],
-            asset=ipv4_asset.IPv4(host="128.0.0.1"),
+            asset=ipv4_asset.IPv4(host="128.0.0.1", mask="32"),
         )
 
         openvas_agent_no_scope.process(scan_message)
@@ -343,7 +343,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
                     vuln_utils.MetadataType.PORT, "80"
                 )
             ],
-            asset=ipv4_asset.IPv4(host="128.0.0.1", version=4),
+            asset=ipv4_asset.IPv4(host="128.0.0.1", version=4, mask="32"),
         )
         args1 = {
             "entry": kb.Entry(
@@ -400,7 +400,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
                     vuln_utils.MetadataType.PORT, "443"
                 )
             ],
-            asset=ipv4_asset.IPv4(host="128.0.0.2", version=4),
+            asset=ipv4_asset.IPv4(host="128.0.0.2", version=4, mask="32"),
         )
         args2 = {
             "entry": kb.Entry(

--- a/tests/openvas_agent_test.py
+++ b/tests/openvas_agent_test.py
@@ -83,6 +83,7 @@ def testAgentOpenVas_whenBinaryAvailable_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
+            dna='{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
         )
 
 
@@ -154,6 +155,7 @@ def testAgentOpenVas_whenLinkAssetAndBinaryAvailable_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
+            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
         )
 
 
@@ -278,6 +280,7 @@ def testAgentOpenVas_whenServiceAssetGiven_RunScan(
             risk_rating=vuln_utils.RiskRating.INFO,
             technical_detail=f"\n```json\n{json.dumps(output, indent=4, sort_keys=True)}\n```",
             vulnerability_location=vulnerability_location,
+            dna='{"location": {"domain_name": {"name": "test"}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
         )
 
 
@@ -361,6 +364,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
             "risk_rating": vuln_utils.RiskRating.INFO,
             "technical_detail": f"\n```json\n{json.dumps(output1, indent=4, sort_keys=True)}\n```",
             "vulnerability_location": vulnerability_location,
+            "dna": '{"location": {"ipv4": {"host": "128.0.0.1", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "80"}]}, "title": ""}',
         }
 
         output2 = {
@@ -417,6 +421,7 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
             "risk_rating": vuln_utils.RiskRating.INFO,
             "technical_detail": f"\n```json\n{json.dumps(output2, indent=4, sort_keys=True)}\n```",
             "vulnerability_location": vulnerability_location,
+            "dna": '{"location": {"ipv4": {"host": "128.0.0.2", "mask": "32", "version": 4}, "metadata": [{"type": "PORT", "value": "443"}]}, "title": ""}',
         }
 
         openvas_agent_no_scope.process(ip_range_message)
@@ -426,6 +431,6 @@ def testAgentOpenVas_whenBinaryAvailableAndRangeOfIPsIsInput_RunScan(
         assert mock_report_vulnerability.call_args_list[0].kwargs == args1
         assert mock_report_vulnerability.call_args_list[1].kwargs == args2
         star_scan_mocker.assert_called_with(
-            f'{ip_range_message.data.get("host")}/{ip_range_message.data.get("mask")}',
+            f"{ip_range_message.data.get('host')}/{ip_range_message.data.get('mask')}",
             None,
         )


### PR DESCRIPTION
The PR is part of Vuln Location/DNA stream:

# The changes are:
- Add a function to compute the dna (using vuln location and vuln_title)
- Add a function to sort the dna dict
- Update the report_vulnarability to use the computed dna


The DNA is calculated using a function that constructs a dictionary `dna_data` of:
- Vulnerability title (vuln_title)
- Vulnerability location (vuln_location)

and returns a JSON string of the dna_data dictionary, sorted by keys.