### PR TITLE
fix: Agent Build Fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM immauss/openvas:22.4.38
+FROM immauss/openvas:22.4.40
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8


### PR DESCRIPTION
## Update Dockerhub Image to Closest one

## Issue
```
Start building agent at 2025-02-26 20:32:25.641303.🔹 Building agent openvas dockerfile Dockerfile at root ..
🔹 Step 1/17 : FROM immauss/openvas:22.4.3
🔺 ERROR: manifest for immauss/openvas:22.4.38 not found: manifest unknown: 
manifest unknow
🔺 ERROR: Error building agent.
```
The Agent Build fails because the image tag is no longer available in Dockerhub
## Fix

Simply Update the image tag to the closes one possible; from `22.4.38` to `22.4.40`

![image](https://github.com/user-attachments/assets/c2dc87e1-b7fb-425c-a008-fa46b78eefea)
 

![image](https://github.com/user-attachments/assets/40a3cb60-20b7-49a5-910c-c2f63bf51527)


![image](https://github.com/user-attachments/assets/4fed3566-2f81-4b56-ad22-c5ed31ee75e4)
