### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,4 +41,4 @@ jobs:
         python -m uv pip install -r tests/test-requirement.txt
     - name: Runnning tests with pytest.
       run: |
-        pytest -m "not docker" --cov-report=term-missing
+        pytest -m "not docker"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,10 +41,4 @@ jobs:
         python -m uv pip install -r tests/test-requirement.txt
     - name: Runnning tests with pytest.
       run: |
-        pytest -m "not docker" --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
-    - name: Upload coverage to Codecov.
-      uses: codecov/codecov-action@v4
-      with:
-        verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        pytest -m "not docker" --cov-report=term-missing


### PR DESCRIPTION
Removes the codecov config file and the coverage upload from the pytest workflow